### PR TITLE
HTI:core version 1.0 - FHIR version can be provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# GIDS Health Tools Interoperability Changelog
+
+## HTI:core version 1.0
+Document version: 1.0  
+Date: 26-4-2021
+
+Upgraded from v0.4 to 1.0 as we've introduced a breaking change. These are the changes provided in 1.0:
+
+### Spec changes
+* The FHIR Task can now be provided with a specific FHIR version by providing the `fhir-v` attribute;
+* The default version of the FHIR Task is now R4 instead of STU3 (breaking change);
+* Changed documentation to point to FHIR R4 documentation instead of STU3;
+* Changed STU3 code samples with R4 code samples;
+  
+### Styling improvements
+* Fixed link pointing to incorrect external source;  
+* Fixed link not pointing to internal anchor;
+* Fixed multiline table layout;
+* Changed links for HTI test suite from `edia-tst.eu` to `gidsopenstandaarden.org` as  these are now hosted by GIDS;   
+* Added this changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Date: 26-4-2021
 Upgraded from v0.4 to 1.0 as we've introduced a breaking change. These are the changes provided in 1.0:
 
 ### Spec changes
-* The FHIR Task can now be provided with a specific FHIR version by providing the `fhir-v` attribute;
+* The FHIR Task can now be provided with a specific FHIR version by providing the `fhir-version` attribute;
 * The default version of the FHIR Task is now R4 instead of STU3 (breaking change);
 * Changed documentation to point to FHIR R4 documentation instead of STU3;
 * Changed STU3 code samples with R4 code samples;

--- a/HTI.md
+++ b/HTI.md
@@ -37,6 +37,39 @@ Date: 26-4-2021
   - [Introduction](#introduction)
   - [The module testsuite](#the-module-testsuite)
 
+- [GIDS Health Tools Interoperability](#gids-health-tools-interoperability)
+    - [Goals and Rationale](#goals-and-rationale)
+    - [About this document](#about-this-document)
+    - [Architecture](#architecture)
+        - [Concepts](#concepts)
+        - [Domain model](#domain-model)
+        - [Assumptions](#assumptions)
+    - [Implementation guide](#implementation-guide)
+        - [Semantic roles and responsibilities](#semantic-roles-and-responsibilities)
+        - [① The FHIR task object](#-the-fhir-task-object)
+        - [② The message format](#-the-message-format)
+        - [③ The message exchange](#-the-message-exchange)
+        - [Putting it all together](#putting-it-all-together)
+    - [Profiles](#profiles)
+        - [FHIR Store profile (HTI:smart_on_fhir)](#fhir-store-profile-htismart_on_fhir)
+        - [JWE message encryption (HTI:jwe)](#jwe-message-encryption-htijwe)
+        - [Restrictions](#restrictions)
+        - [Layout of the message](#layout-of-the-message)
+        - [Tip: JWT and JWE message detection](#tip-jwt-and-jwe-message-detection)
+        - [Configuration and storage requirements](#configuration-and-storage-requirements)
+        - [3rd party launches (HTI:3rdparty)](#3rd-party-launches-hti3rdparty)
+        - [Mapping of the FHIR task](#mapping-of-the-fhir-task)
+        - [Scenario’s](#scenarios)
+- [Implementation checklist](#implementation-checklist)
+    - [The portal application](#the-portal-application)
+    - [The module application](#the-module-application)
+    - [General requirements](#general-requirements)
+- [Connection with the SNS Launch protocol](#connection-with-the-sns-launch-protocol)
+- [Test tools and validators](#test-tools-and-validators)
+    - [Introduction](#introduction)
+    - [The module testsuite](#the-module-testsuite)
+
+
 ## Goals and Rationale
 The GIDS Health Tool Interoperability protocol (HTI) is inspired by the IMS - Learning Tool Interoperability (LTI) which has had a tremendous proven impact on the relation between learner management systems and learning tool providers. The objectives of LTI are:
  1. To provide a mash-up style deployment model which is easy to configure by URL, key and secret.
@@ -279,6 +312,8 @@ The FHIR task object **MUST** be exchanged as part of a JWT token. The FHIR task
 | Task | task | The FHIR Task object in JSON format. |
 | FHIR Version | fhir-version | The FHIR version for the provided `Task`. When this field is not provided, the FHIR version **MUST** be the latest stable FHIR release. Consumers should evaluate this field in a case-insensitive manner. Currently, the following fields are allowed: `STU3`, `R4` and `R5`. It is strongly advised to always set this field, even when using the latest stable FHIR version. This prevents HTI breaking after a new FHIR stable release. |  
 
+The timestamps follows the ["UNIX time"](https://en.wikipedia.org/wiki/Unix_time) convention, being the number of seconds since the epoch.
+
 #### FHIR Version
 The HTI spec doesn't limit itself to a specific version of FHIR. Ideally, the latest Stable FHIR version is used. At least FHIR STU3 should be used. FHIR provides useful documentation to show the bidirectional differences in the Task:
 
@@ -289,8 +324,6 @@ STU3 and R4 only contains a single property required by HTI:
 src.definition : uri as vs -> tgt.instantiatesUri = vs;
 src.definition : Reference as vs -> tgt.instantiatesCanonical = vs;
 ```
-
-The timestamps follows the ["UNIX time"](https://en.wikipedia.org/wiki/Unix_time) convention, being the number of seconds since the epoch.
 
 #### Example message
 The code fragment below shows the FHIR task (in gray) as part of the JWT message payload.  The example uses FHIR STU3, which is not the latest stable FHIR release. In this case, the `fhir-version` is mandatory.

--- a/HTI.md
+++ b/HTI.md
@@ -1,7 +1,7 @@
 # GIDS Health Tools Interoperability 
-HTI:core version 1.0
-
+HTI:core version 1.0  
 Document version: 1.0  
+Current FHIR Stable Version: [R4](http://hl7.org/fhir/R4/)  
 Date: 26-4-2021
 
 ## Goals and Rationale
@@ -245,7 +245,7 @@ The FHIR task object **MUST** be exchanged as part of a JWT token. The FHIR task
 | Issue time | iat | The timestamp of generating the JWT token, the value of this field **MUST** be validated by the module provider to not be in the future. |
 | Expiration time | exp | This value **MUST** be the time-out of the exchange sending it to the client plus the time-out of the exchange used by the client to send it, the value **MUST** be limited to 5 minutes. This value **MUST** be validated by the module provider, any value that exceeds the timeout **MUST** be rejected. |
 | Task | task | The FHIR Task object in JSON format. |
-| FHIR Version | fhir-version | The FHIR version for the provided `Task`. When this field is not provided, the FHIR version **MUST** be the latest stable FHIR release. Consumers should evaluate this field in a case-insensitive manner. Currently, the following fields are allowed: `STU3`, `R4` (current stable release) and `R5`. It is strongly advised to always set this field, even when using the latest stable FHIR version. This prevents HTI breaking after a new FHIR stable release. |  
+| FHIR Version | fhir-version | The FHIR version for the provided `Task`. When this field is not provided, the FHIR version **MUST** be the latest stable FHIR release. Consumers should evaluate this field in a case-insensitive manner. Currently, the following fields are allowed: `STU3`, `R4` and `R5`. It is strongly advised to always set this field, even when using the latest stable FHIR version. This prevents HTI breaking after a new FHIR stable release. |  
 
 #### Example message
 The code fragment below shows the FHIR task (in gray) as part of the JWT message payload.  The example uses FHIR STU3, which is not the latest stable FHIR release. In this case, the `fhir-version` is mandatory.
@@ -401,7 +401,7 @@ This section provides an overview of the requirements and responsibilities in Mo
 | * the functional task, the definition of the task, and the people involved, and |
 | * information about the sending system, the recipient system and the message itself. |
 | The FHIR task object MUST at least use the STU3 version. |
-| The FHIR version MUST be set when not using the latest stable  FHIR version. |
+| The FHIR version MUST be set when not using the latest stable FHIR version. |
 | The JSON serialization MUST be used for FHIR task objects. |
 | The fields used in the FHIR task object MUST match the table FHIR field mapping. |
 | The task id field MUST be persistent over the timeframe the task is active. |

--- a/HTI.md
+++ b/HTI.md
@@ -245,10 +245,10 @@ The FHIR task object **MUST** be exchanged as part of a JWT token. The FHIR task
 | Issue time | iat | The timestamp of generating the JWT token, the value of this field **MUST** be validated by the module provider to not be in the future. |
 | Expiration time | exp | This value **MUST** be the time-out of the exchange sending it to the client plus the time-out of the exchange used by the client to send it, the value **MUST** be limited to 5 minutes. This value **MUST** be validated by the module provider, any value that exceeds the timeout **MUST** be rejected. |
 | Task | task | The FHIR Task object in JSON format. |
-| FHIR Version | fhir-v | The FHIR version for the provided `Task`. When this field is not provided, the FHIR version **MUST** be the latest stable FHIR release. Consumers should evaluate this field in a case-insensitive manner. Currently, the following fields are allowed: `STU3`, `R4` (current stable release) and `R5`. It is strongly advised to always set this field, even when using the latest stable FHIR version. This prevents HTI breaking after a new FHIR stable release. |  
+| FHIR Version | fhir-version | The FHIR version for the provided `Task`. When this field is not provided, the FHIR version **MUST** be the latest stable FHIR release. Consumers should evaluate this field in a case-insensitive manner. Currently, the following fields are allowed: `STU3`, `R4` (current stable release) and `R5`. It is strongly advised to always set this field, even when using the latest stable FHIR version. This prevents HTI breaking after a new FHIR stable release. |  
 
 #### Example message
-The code fragment below shows the FHIR task (in gray) as part of the JWT message payload.  The example uses FHIR STU3, which is not the latest stable FHIR release. In this case, the `fhir-v` is mandatory.
+The code fragment below shows the FHIR task (in gray) as part of the JWT message payload.  The example uses FHIR STU3, which is not the latest stable FHIR release. In this case, the `fhir-version` is mandatory.
 ```json
 {
   "task": {
@@ -263,7 +263,7 @@ The code fragment below shows the FHIR task (in gray) as part of the JWT message
       "reference": "Patient/9"
     }
   },
-  "fhir-v": "STU3",
+  "fhir-version": "STU3",
   "iat": 1585564845,
   "aud": "https://module.example.com",
   "iss": "https://portal.example.com",
@@ -428,7 +428,7 @@ As the creation of the message is the responsibility of the portal application, 
 | The module application **MUST NOT** expose any of the following information in the launch URL:<ul><li>the functional task, the definition of the task, and<li>the people involved, and information about the sending system, the recipient system and the message itself.</li></ul> |
 | The portal application **MAY** additionally identify the user and link that data to the persistent pseudo identifier of the FHIR object. | 
 | The module **MUST** support at least the following JWT signing algorithms: RS256, RS384, and RS512 and ES256, ES384, and ES512 |
-| The Task **MUST** be deserialized with the provided FHIR version (`fhir-v` claim). If the version is not provided, the latest stable FHIR version will be used. |
+| The Task **MUST** be deserialized with the provided FHIR version (`fhir-version` claim). If the version is not provided, the latest stable FHIR version will be used. |
 | The JWT message **MUST** be validated on the following |
 | * The audience (aud) **MUST** match the module application. |
 | * The issuer (iss) **MUST** be known to the system. |

--- a/HTI.md
+++ b/HTI.md
@@ -1,7 +1,7 @@
 # GIDS Health Tools Interoperability 
 HTI:core version 1.0  
 Document version: 1.0  
-Current FHIR Stable Version: [R4](http://hl7.org/fhir/R4/)  
+Current FHIR Stable Version: [R4](http://hl7.org/fhir/R4/) ([see all versions](http://hl7.org/fhir/directory.html))  
 Date: 26-4-2021
 
 ## Goals and Rationale
@@ -246,6 +246,17 @@ The FHIR task object **MUST** be exchanged as part of a JWT token. The FHIR task
 | Expiration time | exp | This value **MUST** be the time-out of the exchange sending it to the client plus the time-out of the exchange used by the client to send it, the value **MUST** be limited to 5 minutes. This value **MUST** be validated by the module provider, any value that exceeds the timeout **MUST** be rejected. |
 | Task | task | The FHIR Task object in JSON format. |
 | FHIR Version | fhir-version | The FHIR version for the provided `Task`. When this field is not provided, the FHIR version **MUST** be the latest stable FHIR release. Consumers should evaluate this field in a case-insensitive manner. Currently, the following fields are allowed: `STU3`, `R4` and `R5`. It is strongly advised to always set this field, even when using the latest stable FHIR version. This prevents HTI breaking after a new FHIR stable release. |  
+
+#### FHIR Version
+The HTI spec doesn't limit itself to a specific version of FHIR. Ideally, the latest Stable FHIR version is used. At least FHIR STU3 should be used. FHIR provides useful documentation to show the bidirectional differences in the Task:
+
+[STU3 ⇆ R4](http://hl7.org/fhir/R4/task-version-maps.html)
+
+STU3 and R4 only contains a single property required by HTI:
+```
+src.definition : uri as vs -> tgt.instantiatesUri = vs;
+src.definition : Reference as vs -> tgt.instantiatesCanonical = vs;
+```
 
 #### Example message
 The code fragment below shows the FHIR task (in gray) as part of the JWT message payload.  The example uses FHIR STU3, which is not the latest stable FHIR release. In this case, the `fhir-version` is mandatory.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # GIDS-HTI-Protocol
-This repository contains the GIDS Health Tool Interoperability (HTI) protocol technical specification. The specification can be found in the [HTI.md](HTI.md) file.
+This repository contains the GIDS Health Tool Interoperability (HTI) protocol technical specification. The specification can be found in the [HTI.md](HTI.md) file. 
+
+Changes are tracked in the [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
## HTI:core version 1.0
Document version: 1.0  
Date: 26-4-2021

Upgraded from v0.4 to 1.0 as we've introduced a breaking change. These are the changes provided in 1.0:

### Spec changes
* The FHIR Task can now be provided with a specific FHIR version by providing the `fhir-v` attribute;
* The default version of the FHIR Task is now R4 instead of STU3 (breaking change);
* Changed documentation to point to FHIR R4 documentation instead of STU3;
* Changed STU3 code samples with R4 code samples;
  
### Styling improvements
* Fixed link pointing to incorrect external source;  
* Fixed link not pointing to internal anchor;
* Fixed multiline table layout;
* Changed links for HTI test suite from `edia-tst.eu` to `gidsopenstandaarden.org` as  these are now hosted by GIDS;   
* Added this changelog.